### PR TITLE
Adds missing dependencies for docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 ARG CLOUD_SDK_VERSION=238.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 
-RUN apk add --no-cache curl python py-crcmod bash libc6-compat openssh-client git gnupg rsync coreutils
+RUN apk add --no-cache curl python py-crcmod py-pip python-dev libffi-dev bash libc6-compat openssh-client openssl-dev git gnupg rsync coreutils gcc libc-dev make
 
 # Install gcloud
 ENV PATH /google-cloud-sdk/bin:$PATH


### PR DESCRIPTION
Some docker compose dependencies were missing causing the install to fail.

https://docs.docker.com/compose/install/