### PR TITLE
change cloud sdk version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine
-ARG CLOUD_SDK_VERSION=238.0.0
+ARG CLOUD_SDK_VERSION=254.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 
 RUN apk add --no-cache curl python py-crcmod py-pip python-dev libffi-dev bash libc6-compat openssh-client openssl-dev git gnupg rsync coreutils gcc libc-dev make


### PR DESCRIPTION
Updates to version 254. This is so Android has access to the `--num-flaky-test-attempts` used to address network latency issues in acceptance testing.