### PR TITLE
Adding python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 ARG CLOUD_SDK_VERSION=254.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 
-RUN apk add --no-cache curl python py-crcmod py-pip python-dev libffi-dev bash libc6-compat openssh-client openssl-dev git gnupg rsync coreutils gcc libc-dev make
+RUN apk add --no-cache curl python python3 py-crcmod py-pip python-dev libffi-dev bash libc6-compat openssh-client openssl-dev git gnupg rsync coreutils gcc libc-dev make
 
 # Install gcloud
 ENV PATH /google-cloud-sdk/bin:$PATH


### PR DESCRIPTION
Python2.7 required for google cloud tools
Python3.7 used by DS and content teams
Both are now installed