### PR TITLE
Readd JQ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine
 ARG CLOUD_SDK_VERSION=324.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 
-RUN apk add --no-cache curl python3 py3-crcmod py3-pip python3-dev libffi-dev bash libc6-compat openssh-client openssl-dev git gnupg rsync coreutils gcc libc-dev make npm ca-certificates ncurses g++ libgcc linux-headers grep util-linux binutils findutils libexecinfo-dev zip
+RUN apk add --no-cache curl python3 py3-crcmod py3-pip python3-dev libffi-dev bash libc6-compat openssh-client openssl-dev git gnupg rsync coreutils gcc libc-dev make npm ca-certificates ncurses g++ libgcc linux-headers grep util-linux binutils findutils libexecinfo-dev zip jq
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
 ENV NVM_DIR /root/.nvm
 ENV PATH $NVM_DIR:$PATH


### PR DESCRIPTION
I accidently removed jq when making a previous commit (oops)!

This library is jq and is used by bash for querying JSON which is required for AWS Lambda functions and is really useful in many other scenarios (npm libs uses it for github responses for example)