### PR TITLE
Python dependencies that fix the build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,27 +6,29 @@ ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 # Dependencies
 RUN apk add --no-cache \ 
     bash \
+    binutils \
     ca-certificates \
     coreutils \ 
     curl \
-    binutils \
     findutils \ 
     g++ \ 
     gcc \
     git \
     gnupg \
     grep \
-    jq libc-dev \
+    jq \
+    libc6-compat \
+    libc-dev \
     libexecinfo-dev \
     libffi-dev \
+    libgcc  \
     linux-headers \
-    libc6-compat \
     make \
+    ncurses \
     npm \ 
-    py3-pip \
-    libgcc ncurses \
     openssh-client \
     openssl-dev \
+    py3-pip \
     python3-dev \
     python3 \
     py3-crcmod \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,37 @@ FROM alpine
 ARG CLOUD_SDK_VERSION=324.0.0
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 
-RUN apk add --no-cache curl python3 py3-crcmod py3-pip python3-dev libffi-dev bash libc6-compat openssh-client openssl-dev git gnupg rsync coreutils gcc libc-dev make npm ca-certificates ncurses g++ libgcc linux-headers grep util-linux binutils findutils libexecinfo-dev zip jq
+# Dependencies
+RUN apk add --no-cache \ 
+    bash \
+    ca-certificates \
+    coreutils \ 
+    curl \
+    binutils \
+    findutils \ 
+    g++ \ 
+    gcc \
+    git \
+    gnupg \
+    grep \
+    jq libc-dev \
+    libexecinfo-dev \
+    libffi-dev \
+    linux-headers \
+    libc6-compat \
+    make \
+    npm \ 
+    py3-pip \
+    libgcc ncurses \
+    openssh-client \
+    openssl-dev \
+    python3-dev \
+    python3 \
+    py3-crcmod \
+    rsync \
+    util-linux \
+    zip 
+
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
 ENV NVM_DIR /root/.nvm
 ENV PATH $NVM_DIR:$PATH
@@ -21,26 +51,26 @@ ENV PATH=/root/.cargo/bin:$PATH
 # Install gcloud
 ENV PATH /google-cloud-sdk/bin:$PATH
 RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
-  tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
-  rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
-  ln -s /lib /lib64 && \
-  gcloud config set core/disable_usage_reporting true && \
-  gcloud config set component_manager/disable_update_check true && \
-  gcloud config set metrics/environment github_docker_image && \
-  gcloud --version
+    tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
+    ln -s /lib /lib64 && \
+    gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true && \
+    gcloud config set metrics/environment github_docker_image && \
+    gcloud --version
 
 # Adds kubectl
 RUN export KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt) \
-  && curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl \
-  && chmod u+x kubectl && mv kubectl /usr/bin/kubectl
+    && curl -LO https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl \
+    && chmod u+x kubectl && mv kubectl /usr/bin/kubectl
 
 # Install docker
 RUN export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.docker.com/linux/static/stable/x86_64/ | grep -o -e 'docker-[.0-9]*-ce\.tgz' | sort -r | head -n 1) \
-  && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/${DOCKER_VERSION}" \
-  && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
-  && tar -xz -C /tmp -f /tmp/docker.tgz \
-  && mv /tmp/docker/* /usr/bin \
-  && rm -rf /tmp/docker /tmp/docker.tgz
+    && DOCKER_URL="https://download.docker.com/linux/static/stable/x86_64/${DOCKER_VERSION}" \
+    && curl --silent --show-error --location --fail --retry 3 --output /tmp/docker.tgz "${DOCKER_URL}" \
+    && tar -xz -C /tmp -f /tmp/docker.tgz \
+    && mv /tmp/docker/* /usr/bin \
+    && rm -rf /tmp/docker /tmp/docker.tgz
 
 # Install docker-compose
 RUN python3 -m ensurepip --upgrade --default-pip && python3 -m pip install --upgrade pip && python3 -m pip install PyYAML -U && pip3 install docker-compose
@@ -48,9 +78,9 @@ RUN python3 -m ensurepip --upgrade --default-pip && python3 -m pip install --upg
 
 # Install git-crypt
 RUN curl --silent --output /etc/apk/keys/sgerrand.rsa.pub https://raw.githubusercontent.com/sgerrand/alpine-pkg-git-crypt/master/sgerrand.rsa.pub && \
-  curl -LO https://github.com/sgerrand/alpine-pkg-git-crypt/releases/download/0.6.0-r1/git-crypt-0.6.0-r1.apk && \
-  apk add --no-cache git-crypt-0.6.0-r1.apk && \
-  rm git-crypt-0.6.0-r1.apk
+    curl -LO https://github.com/sgerrand/alpine-pkg-git-crypt/releases/download/0.6.0-r1/git-crypt-0.6.0-r1.apk && \
+    apk add --no-cache git-crypt-0.6.0-r1.apk && \
+    rm git-crypt-0.6.0-r1.apk
 
 # Install AWS CLI
 ENV PATH /root/.local/bin:$PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ RUN $NVM_DIR/nvm.sh install 8
 RUN $NVM_DIR/nvm.sh install 10
 RUN $NVM_DIR/nvm.sh install 12
 
+# install toolchain for rust as required by cryptography
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- --default-toolchain stable -y
+ENV PATH=/root/.cargo/bin:$PATH
+
 # Install gcloud
 ENV PATH /google-cloud-sdk/bin:$PATH
 RUN curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz && \
@@ -38,7 +43,7 @@ RUN export DOCKER_VERSION=$(curl --silent --fail --retry 3 https://download.dock
   && rm -rf /tmp/docker /tmp/docker.tgz
 
 # Install docker-compose
-RUN python3 -m ensurepip --default-pip && python3 -m pip install PyYAML -U && pip3 install docker-compose
+RUN python3 -m ensurepip --upgrade --default-pip && python3 -m pip install --upgrade pip && python3 -m pip install PyYAML -U && pip3 install docker-compose
 
 
 # Install git-crypt


### PR DESCRIPTION
Long story about `cryptography` package and python that started to cause problems for spider-team a few months back.

The version of Rust (+toolchain) that ships is too low thus breaking building `wheel`

Also to ensure we have the latest pip installed because this was causing some issues.

So I've added the latest toolchain for Rust to be installed and ensured the path is correct.  This is required and now the image builds.  I remember a few folks speaking about this on the net.