### PR TITLE
addition of ts-node for monorepo container

### DIFF
--- a/Dockerfile-MonoRepo
+++ b/Dockerfile-MonoRepo
@@ -12,4 +12,4 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.
   && sudo apt-get update \
   && sudo apt-get install google-cloud-cli
 
-RUN yarn global add turbo
+RUN yarn global add turbo ts-node


### PR DESCRIPTION
Unpacked Size of ts-node.  Super useful.  Small footprint.  Need it!
747 kB