### PR TITLE
dbt image

### DIFF
--- a/Dockerfile-dbt
+++ b/Dockerfile-dbt
@@ -1,0 +1,13 @@
+FROM python:3.8.16-slim-buster
+
+RUN apt-get update && apt-get install -y \
+  curl \
+  git \
+  git-crypt \
+  wget \
+  zip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN pip install \
+  dbt-bigquery~=1.2.0 \
+  sqlfluff-templater-dbt


### PR DESCRIPTION
Add new dockerfile for use with dbt and sqlfluff. This runs on a different version of python to the existing Python file and could potentially be expanded to suit multiple different uses within data engineering in the future.