### PR TITLE
JRE added for SonarCloud testing

### DIFF
--- a/Dockerfile-Sonar
+++ b/Dockerfile-Sonar
@@ -1,5 +1,4 @@
 # Used for test coverage and running tests for Sonic
 FROM playsportsgroup/buildtools
 
-RUN apt-get install -y default-jre && \
-    apt-get clean;
+RUN apk add openjdk12-jre

--- a/Dockerfile-Sonar
+++ b/Dockerfile-Sonar
@@ -1,0 +1,5 @@
+# Used for test coverage and running tests for Sonic
+FROM playsportsgroup/buildtools
+
+RUN apt-get install -y default-jre && \
+    apt-get clean;


### PR DESCRIPTION
The MonoRepo requires that we code analyse after the initial detection of changes.

At this point, we need to run separate async jobs for SonarCloud Test Coverage (in particular).  

Basing the docker image off our existing build tools and adding JRE (Min 11 required apparently for SonarCloud CLI) as in not to bloat our main image with unnecessary dependencies required for this single purpose