### PR TITLE
JDK added for Sonar

### DIFF
--- a/Dockerfile-Sonar
+++ b/Dockerfile-Sonar
@@ -1,4 +1,5 @@
 # Used for test coverage and running tests for Sonic
-FROM playsportsgroup/buildtools
+FROM openjdk:21-slim
 
-RUN apk add openjdk12-jre
+RUN apt-get update && apt-get upgrade -y && apt-get install -y locales
+RUN apt install npm yarn -y


### PR DESCRIPTION
It's easier to base of JDK and only add what we need to install dependencies