### PR TITLE
upgrade cf buildtools to node16

### DIFF
--- a/Dockerfile-Node-CloudFunction
+++ b/Dockerfile-Node-CloudFunction
@@ -1,7 +1,7 @@
 FROM openjdk:8-alpine AS openjava8
 
 #Node version should match target cloud function deploy env
-FROM node:14.21.2-alpine
+FROM node:16.19.0-alpine
 
 COPY --from=openjava8 /usr/lib/jvm/java-1.8-openjdk /usr/lib/jvm/java-1.8-openjdk
 ENV PATH="/usr/lib/jvm/java-1.8-openjdk/bin:${PATH}"

--- a/Dockerfile-Node-CloudFunction-Prerelease
+++ b/Dockerfile-Node-CloudFunction-Prerelease
@@ -1,3 +1,5 @@
+# Not currently in use. Used as part of the node upgrade process.
+
 FROM openjdk:8-alpine AS openjava8
 
 #Node version should match target cloud function deploy env


### PR DESCRIPTION
Upgrades the buildtools used by Tourmalet Cloud Functions. This needs to be merged and the docker image successfully updated before merging this associated PR in TCF https://github.com/PlaySportsGroup/tourmalet-cloud-functions/pull/1013
