### PR TITLE
Data Engineering Docker Image

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @patrickkenyon @timjonesplaysports @pht-psn @patrickm-psn @danielgroves @lucieparsons @Duodutheo
+* @patrickkenyon @timjonesplaysports @pht-psn @danielgroves @lucieparsons

--- a/Dockerfile-DataEng-Tools
+++ b/Dockerfile-DataEng-Tools
@@ -1,0 +1,8 @@
+# Use an Ubuntu base image
+FROM ubuntu:24.04
+
+# Update package lists and install necessary dependencies
+RUN apt-get update && apt-get install -y curl
+
+# Download and install Postman CLI for x64 architecture
+RUN curl -o- "https://dl-cli.pstmn.io/install/linux64.sh" | sh

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Tags are configured in DockerHub.
 | Dockerfile-Prerelease                          | For prerelease of base image                                    | `latest-prerelease`   | Use for testing                                                                     |
 | Dockerfile-Python                              | For Python                                                      | `python-latest`       |                                                                  |
 | Dockerfile-Sonar                               | For SonarCloud                                                  | `sonar`               | Heavy dependencies bloat (requires own image), used for MonoRepo, Derives from DockerFile  |
+| Dockerfile-DataEng-Tools                       | For Data Engineering purposes     |                             |                       |
 
 
 


### PR DESCRIPTION
Docker image for data engineering purposes (In first instance Postman CLI).

- There isn't a Postman CLI docker image anywhere on docker hub, only newman which isn't for the use case we need
- I'm using Ubuntu/Debian because I went down the Alpine route which is a world of dependency complications and hell for saving a few mb (This is 180mg ish).
